### PR TITLE
Target buffer selection

### DIFF
--- a/biblio-core.el
+++ b/biblio-core.el
@@ -503,10 +503,9 @@ BUFFER-NAME is the name of the new target buffer."
              (find-file-noselect (biblio--choose-bib-file))
            (read-buffer
             "Buffer to insert entries into: " nil t
-            (lambda (b) (eq 'bibtex-mode
-                       (buffer-local-value
-                        'major-mode
-                        (get-buffer (if (stringp b) b (car b))))))))))
+            (lambda (candidate)
+              (let ((buf (if (stringp candidate) candidate (car candidate))))
+                (with-current-buffer buf (derived-mode-p 'bibtex-mode))))))))
   (let ((buffer (get-buffer buffer-or-name)))
     (if (buffer-local-value 'buffer-read-only buffer)
         (user-error "%s is read-only" (buffer-name buffer))


### PR DESCRIPTION
Makes the default choice target buffer sensitive to the major-mode of the buffer from which the search was started. 

Also changes the behavior of `biblio--selection-change-buffer`. Now it only offers buffers with major mode derived from from`bibtex-mode`. This uses `directory-name-p` with requires emacs 25.1 but can be avoided.