### PR TITLE
check for advice in addition to checking for completing-read-function having its default value & set more relax url timeout

### DIFF
--- a/biblio-core.el
+++ b/biblio-core.el
@@ -213,7 +213,7 @@ URL and CALLBACK; see `url-queue-retrieve'"
   (if biblio-synchronous
       (with-current-buffer (url-retrieve-synchronously url)
         (funcall callback nil))
-    (setq url-queue-timeout 1)
+    (setq url-queue-timeout 5)
     (url-queue-retrieve url callback)))
 
 (defun biblio-strip (str)
@@ -483,7 +483,8 @@ will be called with the metadata of the current item.")
 
 (defun biblio--completing-read-function ()
   "Return ido, unless user picked another completion package."
-  (if (eq completing-read-function #'completing-read-default)
+  (if (and (eq completing-read-function #'completing-read-default)
+           (not (advice--p (advice--symbol-function #'completing-read-default))))
       #'ido-completing-read
     completing-read-function))
 


### PR DESCRIPTION
For [vertico](https://github.com/minad/vertico) users who want to use vertico(default completing function) to show biblio candicates, they can check for advice of `completing-read-default` to avoid using `ido-completing-read`.

Please check issue https://github.com/cpitclaudel/biblio.el/issues/55

Also, set a more relax url timeout to make sure every url request ok.

Please also check https://github.com/cpitclaudel/biblio.el/issues/39