### PR TITLE
Update DBLP URL from dblp.uni-trier.de to dblp.org

### DIFF
--- a/biblio-dblp.el
+++ b/biblio-dblp.el
@@ -65,7 +65,7 @@
 
 (defun biblio-dblp--url (query)
   "Create a DBLP url to look up QUERY."
-  (format "https://dblp.uni-trier.de/search/publ/api?q=%s&format=xml" (url-encode-url query)))
+  (format "https://dblp.org/search/publ/api?q=%s&format=xml" (url-encode-url query)))
 
 ;;;###autoload
 (defun biblio-dblp-backend (command &optional arg &rest more)


### PR DESCRIPTION
I believe dblp.org is the current URL for DBLP. At the moment, dblp.uni-trier.de is either very slow or unavailable, whereas dblp.org works reliably, at least in my environment.