### PR TITLE
Prevent timezone-parse-date warning closes #63

### DIFF
--- a/biblio-hal.el
+++ b/biblio-hal.el
@@ -28,6 +28,7 @@
 ;;; Code:
 
 (require 'biblio-core)
+(require 'timezone)
 
 (defun biblio-hal--forward-bibtex (metadata forward-to)
   "Forward BibTeX for HAL entry METADATA to FORWARD-TO."


### PR DESCRIPTION
Currently when installing there is a minor warning:

Warning (native-compiler): biblio-hal.el:46:30: Warning: the function ‘timezone-parse-date’ is not known to be defined.

Easy fix is to just require timezone.